### PR TITLE
Update slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The directory structure is dictated by [OpenShift Jenkins S2I image](https://doc
 To Integrate with slack follow the steps at https://github.com/jenkinsci/slack-plugin. Particularly, create a webhook at  https://customteamname.slack.com/services/new/jenkins-ci. After the webhook setup is complete at slack, record and add the below environmental variables. You can retrieve the values on your [slack dashboard](https://my.slack.com/services/new/jenkins-ci). Make sure you are logged into the correct team.
 1. The base url as `SLACK_BASE_URL`
 2. The slack room you selected as the default slack channel as `SLACK_ROOM`
-3. A jenkins credential needs to be created. Use the id of the credential for the environmental variable `SLACK_TOKEN_CREDENTIAL_ID`. When creating this credential in OpenShift, create a secret that syncs withe jenkins and uses the key secrettext. Prepend the namespaces to the credential name. For example, if you create a secret named `slack-token` in the namespace `jenkins` then this variable would be `jenkins-slack-token`.
+3. A jenkins credential needs to be created. Use the id of the credential for the environmental variable `SLACK_TOKEN_CREDENTIAL_ID`. When creating this credential in OpenShift, create a secret that syncs withe jenkins and uses the key secrettext. The namespace will automatically be prepended to the credential name. For example, if you create a secret named `slack-token` in the namespace `jenkins` then this variable would be `slack-token` and jenkins will look for the sync'd credential `jenkins-slack-token`.
 4. Optionally, you can add your slack team name with the variable `SLACK_TEAM`
 
 ## SonarQube Integration

--- a/README.md
+++ b/README.md
@@ -22,6 +22,21 @@ To Integrate with slack follow the steps at https://github.com/jenkinsci/slack-p
 3. A jenkins credential needs to be created. Use the id of the credential for the environmental variable `SLACK_TOKEN_CREDENTIAL_ID`. When creating this credential in OpenShift, create a secret that syncs withe jenkins and uses the key secrettext. The namespace will automatically be prepended to the credential name. For example, if you create a secret named `slack-token` in the namespace `jenkins` then this variable would be `slack-token` and jenkins will look for the sync'd credential `jenkins-slack-token`.
 4. Optionally, you can add your slack team name with the variable `SLACK_TEAM`
 
+Here is an example of the slack token credential secret created in OpenShift
+
+```
+kind: Secret
+type: Opaque
+metadata:
+  labels:
+    credential.sync.jenkins.openshift.io: 'true'
+    build: "jenkins"
+    app: "jenkins"
+  name: "slack-token"
+stringData:
+  secrettext: "super-secret-token"
+```
+
 ## SonarQube Integration
  
 By default the deployment will attempt to connect to SonarQube and configure its setup including an authentication token. The default url is http://sonarqube:9000. This can be overriden adding an environment variable named `SONARQUBE_URL`. To disable SonarQube entirely set an environment variable named `DISABLE_SONAR` with any value.

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ The directory structure is dictated by [OpenShift Jenkins S2I image](https://doc
 
 To Integrate with slack follow the steps at https://github.com/jenkinsci/slack-plugin. Particularly, create a webhook at  https://customteamname.slack.com/services/new/jenkins-ci. After the webhook setup is complete at slack, record and add the below environmental variables. You can retrieve the values on your [slack dashboard](https://my.slack.com/services/new/jenkins-ci). Make sure you are logged into the correct team.
 1. The base url as `SLACK_BASE_URL`
-2. The slack token as `SLACK_TOKEN`
-3. The slack room you selected as the default slack channel as `SLACK_ROOM`
-4. optionally, a jenkins credential can be used for the token and referenced by a custom id at `SLACK_TOKEN_CREDENTIAL_ID`. This takes precedences over the `SLACK_TOKEN`
+2. The slack room you selected as the default slack channel as `SLACK_ROOM`
+3. A jenkins credential needs to be created. Use the id of the credential for the environmental variable `SLACK_TOKEN_CREDENTIAL_ID`. When creating this credential in OpenShift, create a secret that syncs withe jenkins and uses the key secrettext. Prepend the namespaces to the credential name. For example, if you create a secret named `slack-token` in the namespace `jenkins` then this variable would be `jenkins-slack-token`.
+4. Optionally, you can add your slack team name with the variable `SLACK_TEAM`
 
 ## SonarQube Integration
  

--- a/configuration/init.groovy.d/configure-slack.groovy
+++ b/configuration/init.groovy.d/configure-slack.groovy
@@ -16,9 +16,9 @@ if(slackBaseUrl != null) {
   def slack = Jenkins.instance.getDescriptorByType(jenkins.plugins.slack.SlackNotifier.DescriptorImpl)
 
   slack.baseUrl = slackBaseUrl
-  slack.teamDomain = slackTeamDomain
-  slack.tokenCredentialId = slackTokenCredentialId
-  slack.room = slackRoom
+  slack.teamDomain = slackTeamDomain ?: ''
+  slack.tokenCredentialId = slackTokenCredentialId ? System.getenv('OPENSHIFT_BUILD_NAMESPACE') + "-" + slackTokenCredentialId : ''
+  slack.room = slackRoom ?: '#jenkins'
   slack.save()
 
   LOG.log(Level.INFO,  'Configured slack' )

--- a/configuration/init.groovy.d/configure-slack.groovy
+++ b/configuration/init.groovy.d/configure-slack.groovy
@@ -1,6 +1,4 @@
 import jenkins.model.Jenkins
-import net.sf.json.JSONObject
-
 import java.util.logging.Level
 import java.util.logging.Logger
 
@@ -10,35 +8,20 @@ final def LOG = Logger.getLogger("LABS")
 if(slackBaseUrl != null) {
 
   LOG.log(Level.INFO,  'Configuring slack...' )
-  
-  def slackToken = System.getenv('SLACK_TOKEN')
+
   def slackRoom = System.getenv('SLACK_ROOM')
-  def slackSendAs = ''
-  def slackTeamDomain = ''
+  def slackTeamDomain = System.getenv('SLACK_TEAM')
   def slackTokenCredentialId = System.getenv('SLACK_TOKEN_CREDENTIAL_ID')
 
-  if(slackTokenCredentialId == null) {
-    slackTokenCredentialId = ''
-  }
+  def slack = Jenkins.instance.getDescriptorByType(jenkins.plugins.slack.SlackNotifier.DescriptorImpl)
 
-  JSONObject formData = ['slack': ['tokenCredentialId': slackTokenCredentialId]] as JSONObject
-
-  def slack = Jenkins.instance.getExtensionList(
-    jenkins.plugins.slack.SlackNotifier.DescriptorImpl.class
-  )[0]
-  def params = [
-    slackBaseUrl: slackBaseUrl,
-    slackTeamDomain: slackTeamDomain,
-    slackToken: slackToken,
-    slackRoom: slackRoom,
-    slackSendAs: slackSendAs
-  ]
-  def req = [
-    getParameter: { name -> params[name] }
-  ] as org.kohsuke.stapler.StaplerRequest
-  slack.configure(req, formData)
+  slack.baseUrl = slackBaseUrl
+  slack.teamDomain = slackTeamDomain
+  slack.tokenCredentialId = slackTokenCredentialId
+  slack.room = slackRoom
+  slack.save()
 
   LOG.log(Level.INFO,  'Configured slack' )
 
-  slack.save()
 }
+

--- a/plugins.txt
+++ b/plugins.txt
@@ -146,7 +146,7 @@ ruby-runtime:0.12
 run-condition:1.2
 scm-api:2.6.3
 script-security:1.62
-slack:2.32
+slack:2.34
 sonar:2.9
 sse-gateway:1.19
 ssh-agent:1.17


### PR DESCRIPTION
Slack configuration was broken. This PR fixes the integration. The plugin is not supporting a reference to the slack token in plain text format. The script will now only except a reference to the slack token via a credential (see OCP secret example below).


```
kind: Secret
type: Opaque
metadata:
  labels:
    credential.sync.jenkins.openshift.io: 'true'
    build: "jenkins"
    app: "jenkins"
  name: "slack-token"
stringData:
  secrettext: "super-secret-token"
```

cc: @pcarney8 @haithamshahin333 