### PR TITLE
🐚 build_image id added 🐚

### DIFF
--- a/.github/workflows/jenkins-image-pr.yaml
+++ b/.github/workflows/jenkins-image-pr.yaml
@@ -27,6 +27,7 @@ jobs:
         run: |
           ./s2i build --as-dockerfile Dockerfile . quay.io/openshift/origin-jenkins:latest  ${{ env.image_name }}:${{ steps.image_tags.outputs.IMAGE_TAGS }} --loglevel 1 
       - name: Build image
+        id: build_image
         uses: redhat-actions/buildah-build@v2.6
         with:
           image: ${{ env.image_name }}

--- a/.github/workflows/jenkins-image-publish.yaml
+++ b/.github/workflows/jenkins-image-publish.yaml
@@ -33,6 +33,7 @@ jobs:
         run: |
           ./s2i build --as-dockerfile Dockerfile . quay.io/openshift/origin-jenkins:latest  ${{ env.image_name }}:${{ steps.image_tags.outputs.IMAGE_TAGS }} --loglevel 1 
       - name: Build image
+        id: build_image
         uses: redhat-actions/buildah-build@v2.6
         with:
           image: ${{ env.image_name }}


### PR DESCRIPTION
Push action was failed due to missing `id: build_image` in the previous step.

cc: @eformat 