### PR TITLE
Add jobcacher plugin for optional use in pipelines

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -173,3 +173,4 @@ jquery-detached:1.2.1
 build-monitor-plugin:1.12+build.201809061734
 github-branch-source:2.11.1
 gitea:1.4.1
+jobcacher:264.vb_f4770b_79801


### PR DESCRIPTION
https://plugins.jenkins.io/jobcacher/

Would like to use this plugin to temporarily cache a CVE list hosted from a rate-limited service for use by a security scanner in a pipeline 🙂 